### PR TITLE
key_configurator: replace invalid license characters

### DIFF
--- a/key_configurator/key_configurator.py
+++ b/key_configurator/key_configurator.py
@@ -9,7 +9,7 @@
 # this software subject to the terms herein.  With respect to the foregoing patent 
 # license, such license is granted  solely to the extent that any such patent is necessary 
 # to Utilize the software alone.  The patent license shall not apply to any combinations which 
-# include this software, other than combinations with devices manufactured by or for TI (TI Devices).
+# include this software, other than combinations with devices manufactured by or for TI ("TI Devices").
 # No hardware patent is licensed hereunder.
 #
 # Redistributions must preserve existing copyright notices and reproduce this license (including the 

--- a/key_configurator/key_configurator.py
+++ b/key_configurator/key_configurator.py
@@ -9,7 +9,7 @@
 # this software subject to the terms herein.  With respect to the foregoing patent 
 # license, such license is granted  solely to the extent that any such patent is necessary 
 # to Utilize the software alone.  The patent license shall not apply to any combinations which 
-# include this software, other than combinations with devices manufactured by or for TI (�TI Devices�).  
+# include this software, other than combinations with devices manufactured by or for TI (TI Devices).
 # No hardware patent is licensed hereunder.
 #
 # Redistributions must preserve existing copyright notices and reproduce this license (including the 
@@ -37,9 +37,9 @@
 #
 # DISCLAIMER.
 #
-# THIS SOFTWARE IS PROVIDED BY TI AND TI�S LICENSORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, 
+# THIS SOFTWARE IS PROVIDED BY TI AND TI'S LICENSORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
 # BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-# IN NO EVENT SHALL TI AND TI�S LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+# IN NO EVENT SHALL TI AND TI'S LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, 
 # OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 


### PR DESCRIPTION
## Summary

- Replace corrupted replacement characters in the key configurator license header.
- Keep the change limited to the issue-reported non-ASCII characters.

Fixes #1

## Validation

- Scanned `key_configurator/key_configurator.py` for non-printable and non-ASCII characters: PASS
- `python3 -m py_compile key_configurator/key_configurator.py`: PASS
- `git diff --check origin/release...HEAD`: PASS
